### PR TITLE
[-mode=docker] Compile the pipeline in docker before using it in other images

### DIFF
--- a/exec/cmd.go
+++ b/exec/cmd.go
@@ -17,7 +17,8 @@ type RunOpts struct {
 	Env    []string
 }
 
-func RunCommandWithOpts(ctx context.Context, opts RunOpts) error {
+// CommandWithOpts returns the equivalent *exec.Cmd that matches the RunOpts provided (opts).
+func CommandWithOpts(ctx context.Context, opts RunOpts) *exec.Cmd {
 	c := exec.CommandContext(ctx, opts.Name, opts.Args...)
 	c.Dir = opts.Path
 
@@ -31,7 +32,13 @@ func RunCommandWithOpts(ctx context.Context, opts RunOpts) error {
 
 	c.Env = opts.Env
 
-	return c.Run()
+	return c
+}
+
+// RunCommandWithOpts runs the command defined by the RunOpts provided (opts).
+// Be warned that the stdout and stderr are not captured by this function and are instead written to opts.Stdout/opts.Stderr.
+func RunCommandWithOpts(ctx context.Context, opts RunOpts) error {
+	return CommandWithOpts(ctx, opts).Run()
 }
 
 // RunCommandAt runs a given command and set of arguments at the given location

--- a/golang/build.go
+++ b/golang/build.go
@@ -9,7 +9,7 @@ import (
 
 func BuildStep(pkg, output string) pipeline.Step {
 	return pipeline.NewStep(func(ctx context.Context, opts pipeline.ActionOpts) error {
-		return x.Build(ctx, x.BuildOpts{
+		return x.RunBuild(ctx, x.BuildOpts{
 			Pkg:    pkg,
 			Output: output,
 			Stdout: opts.Stdout,

--- a/golang/x/build.go
+++ b/golang/x/build.go
@@ -3,8 +3,9 @@ package x
 import (
 	"context"
 	"io"
+	"os/exec"
 
-	"github.com/grafana/shipwright/exec"
+	swexec "github.com/grafana/shipwright/exec"
 )
 
 type BuildOpts struct {
@@ -17,8 +18,8 @@ type BuildOpts struct {
 	Stderr io.Writer
 }
 
-func Build(ctx context.Context, opts BuildOpts) error {
-	return exec.RunCommandWithOpts(ctx, exec.RunOpts{
+func Build(ctx context.Context, opts BuildOpts) *exec.Cmd {
+	return swexec.CommandWithOpts(ctx, swexec.RunOpts{
 		Stdout: opts.Stdout,
 		Stderr: opts.Stderr,
 		Path:   opts.Module,
@@ -26,4 +27,8 @@ func Build(ctx context.Context, opts BuildOpts) error {
 		Args:   []string{"build", "-o", opts.Output, opts.Pkg},
 		Env:    opts.Env,
 	})
+}
+
+func RunBuild(ctx context.Context, opts BuildOpts) error {
+	return Build(ctx, opts).Run()
 }

--- a/plumbing/pipeline/build.go
+++ b/plumbing/pipeline/build.go
@@ -1,0 +1,1 @@
+package pipeline

--- a/plumbing/pipeline/clients/docker/client.go
+++ b/plumbing/pipeline/clients/docker/client.go
@@ -51,6 +51,8 @@ func (c *Client) buildPipeline(ctx context.Context) (string, error) {
 	}
 
 	env := []string{
+		"GOOS=linux",
+		"GOARCH=amd64",
 		"CGO_ENABLED=0",
 	}
 

--- a/plumbing/pipeline/clients/docker/client.go
+++ b/plumbing/pipeline/clients/docker/client.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,11 +10,11 @@ import (
 	"strings"
 	"time"
 
-	golangx "github.com/grafana/shipwright/golang/x"
 	"github.com/grafana/shipwright/plumbing"
 	"github.com/grafana/shipwright/plumbing/cmdutil"
 	"github.com/grafana/shipwright/plumbing/pipeline"
 	"github.com/grafana/shipwright/plumbing/pipeline/clients/cli"
+	"github.com/grafana/shipwright/plumbing/pipelineutil"
 	"github.com/grafana/shipwright/plumbing/plog"
 	"github.com/grafana/shipwright/plumbing/syncutil"
 	"github.com/sirupsen/logrus"
@@ -37,41 +36,54 @@ func (c *Client) Validate(step pipeline.Step) error {
 	return nil
 }
 
-// buildPipeline compiles the provided pipeline so that it can be mounted in a container without requiring that the pipeline has the shipwright command or go installed.
+// buildPipeline creates a docker container that compiles the provided pipeline so that the compiled pipeline can be mounted in
+// other containers without requiring that the container has the shipwright command or go installed.
 func (c *Client) buildPipeline(ctx context.Context) (string, error) {
 	p, err := os.MkdirTemp(os.TempDir(), "shipwright-")
 	if err != nil {
 		return "", fmt.Errorf("error creating temporary directory: %w", err)
 	}
 
-	path := filepath.Join(p, "pipeline")
-	var (
-		stdout = bytes.NewBuffer(nil)
-		stderr = bytes.NewBuffer(nil)
-	)
-
-	c.Log.Warnf("Building pipeline binary '%s' at '%s' for use in docker container...", c.Opts.Args.Path, path)
+	c.Log.Warnf("Building pipeline binary '%s' at '%s' for use in docker container...", c.Opts.Args.Path, p)
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("error getting current working directory: %w", err)
 	}
 
-	if err := golangx.Build(ctx, golangx.BuildOpts{
-		Pkg:    c.Opts.Args.Path,
-		Module: wd,
-		Output: path,
-		Stdout: stdout,
-		Stderr: stderr,
-		Env: []string{
-			fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
-			fmt.Sprintf("GOPATH=%s", os.Getenv("GOPATH")),
-			"CGO_ENABLED=0",
-		},
-	}); err != nil {
-		return "", fmt.Errorf("error compiling pipeline binary: %w\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	env := []string{
+		"CGO_ENABLED=0",
 	}
 
-	return path, nil
+	output := filepath.Join(p, "pipeline")
+	cmd := pipelineutil.GoBuild(ctx, pipelineutil.GoBuildOpts{
+		Pipeline: c.Opts.Args.Path,
+		Module:   wd,
+		Output:   output,
+	})
+
+	opts := RunOpts{
+		Stdout:  c.Log.WithField("stream", "stdout").Writer(),
+		Stderr:  c.Log.WithField("stream", "stderr").Writer(),
+		Image:   plumbing.SubImage("go", c.Opts.Version),
+		Command: cmd.Args[0],
+		Args:    cmd.Args[1:],
+		Env:     env,
+		Volumes: []string{
+			fmt.Sprintf("%s:%s", p, p),
+			fmt.Sprintf("%s:/var/shipwright", wd),
+		},
+	}
+
+	c.Log.Infof("Running docker command '%s'", append([]string{"docker"}, RunArgs(opts)...))
+	// This should run a command very similar to this:
+	// docker run --rm -v $TMPDIR:/var/shipwright shipwright/go:{version} go build -o /var/shipwright/pipeline ./{pipeline}
+	if err := Run(ctx, opts); err != nil {
+		return "", err
+	}
+
+	c.Log.Infof("Successfully compiled pipeline at '%s'", output)
+
+	return output, nil
 }
 
 func (c *Client) Done(ctx context.Context, w pipeline.Walker) error {
@@ -81,7 +93,7 @@ func (c *Client) Done(ctx context.Context, w pipeline.Walker) error {
 	// without requiring that every image has a copy of the shipwright binary
 	p, err := c.buildPipeline(ctx)
 	if err != nil {
-		logger.Fatalln("failed to compile the pipeline", err.Error())
+		return fmt.Errorf("failed to compile the pipeline in docker. Error: %w", err)
 	}
 
 	return w.Walk(ctx, func(ctx context.Context, steps ...pipeline.Step) error {
@@ -223,12 +235,13 @@ func (c *Client) runAction(ctx context.Context, pipelinePath string, step pipeli
 	}
 
 	runOpts := RunOpts{
-		PipelinePath: pipelinePath,
-		Image:        step.Image,
-		Command:      PipelineVolumePath,
-		Volumes:      []string{},
-		Args:         args,
+		Image:   step.Image,
+		Command: PipelineVolumePath,
+		Volumes: []string{},
+		Args:    args,
 	}
+
+	runOpts = runOpts.WithPipelinePath(pipelinePath)
 
 	runOpts, err = c.applyArguments(runOpts, step.Arguments)
 	if err != nil {
@@ -247,8 +260,8 @@ func (c *Client) runAction(ctx context.Context, pipelinePath string, step pipeli
 
 func (c *Client) wrap(pipelinePath string, step pipeline.Step) pipeline.Step {
 	step.Action = func(ctx context.Context, opts pipeline.ActionOpts) error {
-		opts.Stdout = os.Stdout
-		opts.Stderr = os.Stderr
+		opts.Stdout = c.Log.WithField("stream", "stdout").Writer()
+		opts.Stderr = c.Log.WithField("stream", "stderr").Writer()
 
 		if err := c.runAction(ctx, pipelinePath, step)(ctx, opts); err != nil {
 			return err

--- a/plumbing/pipeline/clients/docker/run.go
+++ b/plumbing/pipeline/clients/docker/run.go
@@ -11,27 +11,43 @@ import (
 const PipelineVolumePath = "/var/pipeline"
 
 type RunOpts struct {
-	PipelinePath string
-	Image        string
-	Command      string
-	Volumes      []string
-	Args         []string
+	Image   string
+	Command string
+	Volumes []string
+	Args    []string
+	Env     []string
 
 	Stdout io.Writer
 	Stderr io.Writer
 }
 
-func RunArgs(opts RunOpts) []string {
-	volumes := []string{
-		"-v", fmt.Sprintf("%s:%s", opts.PipelinePath, "/var/pipeline"),
+func (opts RunOpts) WithPipelinePath(path string) RunOpts {
+	if opts.Volumes == nil {
+		opts.Volumes = []string{}
 	}
+
+	opts.Volumes = append(opts.Volumes, fmt.Sprintf("%s:%s", path, "/var/pipeline"))
+
+	return opts
+}
+
+func RunArgs(opts RunOpts) []string {
+	var (
+		volumes = []string{}
+		env     = []string{}
+	)
 
 	for _, v := range opts.Volumes {
 		volumes = append(volumes, "-v", v)
 	}
 
+	for _, v := range opts.Env {
+		env = append(env, "-e", v)
+	}
+
 	args := []string{"run", "--rm"}
 	args = append(args, volumes...)
+	args = append(args, env...)
 	args = append(args, opts.Image)
 	args = append(args, opts.Command)
 	args = append(args, opts.Args...)

--- a/plumbing/pipeline/clients/docker/run_test.go
+++ b/plumbing/pipeline/clients/docker/run_test.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunArgs(t *testing.T) {
+	opts := RunOpts{
+		Image:   "golang:latest",
+		Command: "go",
+		Args:    []string{"test", "./..."},
+		Env:     []string{"ENV_1=1", "ENV_2=2"},
+		Volumes: []string{"/var/volume1:/usr/share/volume1", "/var/volume2:/usr/share/volume2"},
+	}
+
+	expect := strings.Split("run --rm -v /var/volume1:/usr/share/volume1 -v /var/volume2:/usr/share/volume2 -e ENV_1=1 -e ENV_2=2 golang:latest go test ./...", " ")
+
+	val := RunArgs(opts)
+	t.Logf("Comparing (received) '%+v' to (expected) '%+v'", val, expect)
+
+	for i, v := range expect {
+		if val[i] != v {
+			t.Fatalf("got '%s' at position '%d', expected '%s'", val[i], i, v)
+		}
+	}
+}

--- a/plumbing/pipeline/clients/drone/client_test.go
+++ b/plumbing/pipeline/clients/drone/client_test.go
@@ -21,15 +21,15 @@ func TestDroneClient(t *testing.T) {
 		testutil.WithTimeout(time.Second*10, func(t *testing.T) {
 			var (
 				buf          = bytes.NewBuffer(nil)
-				errBuff      = bytes.NewBuffer(nil)
 				ctx          = context.Background()
 				pipelinePath = "../../../../demo/basic"
 				path         = "./demo/basic"
 			)
 
-			testutil.RunPipeline(ctx, t, pipelinePath, io.MultiWriter(buf, os.Stdout), errBuff, &plumbing.PipelineArgs{
-				Mode: plumbing.RunModeDrone,
-				Path: path,
+			testutil.RunPipeline(ctx, t, pipelinePath, io.MultiWriter(buf, os.Stdout), os.Stderr, &plumbing.PipelineArgs{
+				BuildID: "test",
+				Mode:    plumbing.RunModeDrone,
+				Path:    path,
 			})
 
 			expected, err := os.Open(filepath.Join(pipelinePath, "gen_drone.yml"))

--- a/plumbing/pipelineutil/build.go
+++ b/plumbing/pipelineutil/build.go
@@ -1,0 +1,83 @@
+package pipelineutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	golangx "github.com/grafana/shipwright/golang/x"
+)
+
+// GoBuildOpts is the list of (mostly) optional arguments that can be provided when building a pipeline into a static binary.
+// The goal of compiling the pipeline into a binary is that it will be mounted into a container and used in that container.
+type GoBuildOpts struct {
+	// Pipeline is the path to the pipeline that you want to compile.
+	// This path should be a `go build` compatible path.
+	Pipeline string
+	// Module is the path to the root module of the project that defines the go.mod/go.sum for the pipeline.
+	// If this value is not provided, then 'GoBuild' will assume this is the value of 'os.Getwd'.
+	Module string
+	// GoOS sets the "GOOS" environment variable.
+	// if not set, will not be supplied to the command, defaulting it to the current OS.
+	GoOS string // GoArch sets the "GOARCH" environment variable.
+	// If not set, will not be supplied to the command, defaulting it to the current architecture.
+	GoArch string
+	// GoModCache sets the "GOMODCACHE" environment variable.
+	// 'go build' requires a location to search for the go module cache.
+	// if this is not set, then it uses the value available from the current environment using 'os.Getenv'.
+	GoModCache string
+	// GoPath sets the "GOPATH" environment variable.
+	// 'go build' requires a $GOPATH to be set.
+	// if this is not set, then it uses the value available from the current environment using 'os.Getenv'.
+	GoPath string
+	// Output is used as the '-o' argument in the go build command.
+	// If this is not set, then we do not provide it, causing the compiled pipeline to be built in the 'os.Getwd', with a potentially confusing or ambiguous (or even colliding) name.
+	Output string
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func goBuildEnv(opts GoBuildOpts) []string {
+	env := []string{
+		"CGO_ENABLED=0",
+	}
+	var (
+		goOS       = opts.GoOS
+		goArch     = opts.GoArch
+		goModCache = opts.GoModCache
+	)
+
+	if goOS != "" {
+		env = append(env, fmt.Sprintf("GOOS=%s", goOS))
+	}
+	if goArch != "" {
+		env = append(env, fmt.Sprintf("GOARCH=%s", goArch))
+	}
+
+	if goModCache == "" {
+		goModCache = os.Getenv("GOMODCACHE")
+	}
+
+	env = append(env, fmt.Sprintf("GOMODCACHE=%s", goModCache))
+	return env
+}
+
+// GoBuild returns the *exec.Cmd will, if ran, statically compile the pipeline provided in the arguments.
+// This function shells out to the 'go' process, so ensure that 'go' is installed and available in the current environment.
+// We have to shell out because Go does not provide a stdlib function for running 'go build' without the 'go' command.
+func GoBuild(ctx context.Context, opts GoBuildOpts) *exec.Cmd {
+	var (
+		wd  = filepath.Clean(opts.Module)
+		env = goBuildEnv(opts)
+	)
+
+	return golangx.Build(ctx, golangx.BuildOpts{
+		Pkg:    opts.Pipeline,
+		Module: wd,
+		Env:    env,
+		Output: opts.Output,
+	})
+}

--- a/plumbing/pipelineutil/doc.go
+++ b/plumbing/pipelineutil/doc.go
@@ -1,0 +1,2 @@
+// Package pipelineutil defines utilities for working with Pipelines and is separated as it may also import packages that import pipeline.
+package pipelineutil

--- a/plumbing/testutil/pipeline.go
+++ b/plumbing/testutil/pipeline.go
@@ -12,15 +12,18 @@ import (
 )
 
 func RunPipeline(ctx context.Context, t *testing.T, path string, stdout io.Writer, stderr io.Writer, args *plumbing.PipelineArgs) {
-	buf := bytes.NewBuffer(nil)
+	stderrBuf := bytes.NewBuffer(nil)
+	stdoutBuf := bytes.NewBuffer(nil)
 	t.Log("Running pipeline with args", args)
-	if err := commands.Run(ctx, &commands.RunOpts{
+	cmd := commands.Run(ctx, &commands.RunOpts{
 		Path:   path,
-		Stdout: stdout,
-		Stderr: io.MultiWriter(stderr, buf),
+		Stdout: io.MultiWriter(stdout, stdoutBuf),
+		Stderr: io.MultiWriter(stderr, stderrBuf),
 		Args:   args,
-	}); err != nil {
-		t.Fatalf("Error running pipeline. Error: '%s'\nStderr: '%s'\n", err, buf.String())
+	})
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Error running pipeline. Error: '%s'\nStdout: '%s'\nStderr: '%s'\n", err, stdoutBuf.String(), stderrBuf.String())
 	}
 }
 


### PR DESCRIPTION
For docker-driven pipelines, this is probably a practice that we should continue to use.

For example, in Drone or Circle CI, we should compile the pipeline as the first step in the process, and then use that compiled pipeline in the following steps.

Fixes https://github.com/grafana/shipwright/issues/17