### PR TITLE
Drone pipeliens now compile the pipeline first.

### DIFF
--- a/demo/basic/gen_drone.yml
+++ b/demo/basic/gen_drone.yml
@@ -8,48 +8,88 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/basic
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: install-frontend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=0 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=0 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: install-backend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-frontend-dependencies
 
 - name: write-version-file
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=2 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=2 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: compile-backend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=6 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=6 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - write-version-file
 
 - name: compile-frontend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - compile-backend
 
 - name: publish
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=10 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
+  - /var/shipwright/pipeline -step=10 -build-id=$DRONE_BUILD_NUMBER ./demo/basic
   environment:
     secret-gcs-publish-key:
       from_secret: gcs-publish-key
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - compile-frontend
+
+volumes:
+- name: shipwright
+  temp: {}
 
 trigger:
   branch:

--- a/demo/complex/gen_drone.yml
+++ b/demo/complex/gen_drone.yml
@@ -1,0 +1,208 @@
+---
+kind: pipeline
+type: docker
+name: complex-pipeline
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/complex
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
+- name: redis
+  image: redis:6
+  commands:
+  - /var/shipwright/pipeline -step=0 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
+
+- name: initalize
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=2 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
+
+- name: build-backend
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=4 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - initalize
+
+- name: build-frontend
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=5 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - initalize
+
+- name: build-documentation
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=6 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - initalize
+
+- name: test-backend
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - build-backend
+  - build-frontend
+  - build-documentation
+
+- name: test-frontend
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=9 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - build-backend
+  - build-frontend
+  - build-documentation
+
+- name: integration-tests:-sqlite
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=11 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - test-backend
+  - test-frontend
+
+- name: integration-tests:-postgres
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=12 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - integration-tests:-sqlite
+
+- name: integration-tests:-mysql
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=13 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - integration-tests:-postgres
+
+- name: integration-tests:-mssql
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=14 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - integration-tests:-mysql
+
+- name: package
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=19 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - integration-tests:-mssql
+
+- name: build-docker-image
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=20 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - package
+
+- name: publish-documentation
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=23 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - build-docker-image
+
+- name: publish-package
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=24 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - build-docker-image
+
+- name: publish-docker-image
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=25 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - build-docker-image
+
+- name: notify-slack
+  image: grafana/shipwright:latest
+  commands:
+  - /var/shipwright/pipeline -step=27 -build-id=$DRONE_BUILD_NUMBER ./demo/complex
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - publish-documentation
+  - publish-package
+  - publish-docker-image
+
+volumes:
+- name: shipwright
+  temp: {}
+
+...

--- a/demo/generate.sh
+++ b/demo/generate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for demo in ./demo/* ; do
+    if [ -d "$demo" ]; then
+      go run $demo -path=$demo -mode=drone -log-level=debug > $demo/gen_drone.yml
+    fi
+done

--- a/demo/multi-sub/gen_drone.yml
+++ b/demo/multi-sub/gen_drone.yml
@@ -8,17 +8,45 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/multi-sub
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: codeql
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: notify-slack
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=2 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=2 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - codeql
+
+volumes:
+- name: shipwright
+  temp: {}
 
 ---
 kind: pipeline
@@ -30,31 +58,65 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/multi-sub
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: install-frontend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: install-backend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-frontend-dependencies
 
 - name: test-backend
-  image: ghcr.io/grafana/shipwright/go:latest
+  image: grafana/shipwright:latest-go
   commands:
-  - shipwright -step=11 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=11 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: test-frontend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=12 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=12 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
+
+volumes:
+- name: shipwright
+  temp: {}
 
 ---
 kind: pipeline
@@ -66,42 +128,79 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/multi-sub
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: install-frontend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: install-backend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=16 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=16 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-frontend-dependencies
 
 - name: compile-backend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=19 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=19 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: compile-frontend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=20 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=20 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: publish
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=22 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
+  - /var/shipwright/pipeline -step=22 -build-id=$DRONE_BUILD_NUMBER ./demo/multi-sub
   environment:
     secret-gcp-publish-key:
       from_secret: gcp-publish-key
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - compile-backend
   - compile-frontend
+
+volumes:
+- name: shipwright
+  temp: {}
 
 trigger:
   branch:

--- a/demo/multi/gen_drone.yml
+++ b/demo/multi/gen_drone.yml
@@ -8,31 +8,65 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/multi
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: install-frontend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=0 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=0 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: install-backend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-frontend-dependencies
 
 - name: test-backend
-  image: ghcr.io/grafana/shipwright/go:latest
+  image: grafana/shipwright:latest-go
   commands:
-  - shipwright -step=4 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=4 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: test-frontend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=5 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=5 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
+
+volumes:
+- name: shipwright
+  temp: {}
 
 ---
 kind: pipeline
@@ -44,42 +78,79 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/multi
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: install-frontend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: install-backend-dependencies
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=9 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=9 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-frontend-dependencies
 
 - name: compile-backend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=12 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=12 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: compile-frontend
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=13 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=13 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - install-backend-dependencies
 
 - name: publish
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
+  - /var/shipwright/pipeline -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/multi
   environment:
     secret-gcp-publish-key:
       from_secret: gcp-publish-key
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - compile-backend
   - compile-frontend
+
+volumes:
+- name: shipwright
+  temp: {}
 
 trigger:
   branch:

--- a/demo/sub/gen_drone.yml
+++ b/demo/sub/gen_drone.yml
@@ -8,45 +8,85 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/sub
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: step-1
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=7 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: step-2
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=8 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - step-1
 
 - name: step-3
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=9 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=9 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - step-2
 
 - name: step-4
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=13 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=13 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - step-3
 
 - name: step-5
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=14 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=14 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - step-3
 
 - name: step-6
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=15 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - step-3
+
+volumes:
+- name: shipwright
+  temp: {}
 
 ---
 kind: pipeline
@@ -58,23 +98,54 @@ platform:
   arch: amd64
 
 steps:
+- name: builtin-compile-pipeline
+  image: grafana/shipwright:latest-go
+  command:
+  - go
+  - build
+  - -o
+  - /var/shipwright/pipeline
+  - ./demo/sub
+  environment:
+    CGO_ENABLED: 0
+    GOARCH: amd64
+    GOOS: linux
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+
 - name: sub-step-1
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=1 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
+  depends_on:
+  - builtin-compile-pipeline
 
 - name: sub-step-2
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=3 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=3 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - sub-step-1
 
 - name: sub-step-3
-  image: ghcr.io/grafana/shipwright:latest
+  image: grafana/shipwright:latest
   commands:
-  - shipwright -step=4 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  - /var/shipwright/pipeline -step=4 -build-id=$DRONE_BUILD_NUMBER ./demo/sub
+  volumes:
+  - name: shipwright
+    path: /var/shipwright
   depends_on:
   - sub-step-1
+
+volumes:
+- name: shipwright
+  temp: {}
 
 ...

--- a/plumbing/args.go
+++ b/plumbing/args.go
@@ -25,7 +25,7 @@ type PipelineArgs struct {
 
 	// Step defines a specific step to run. Typically this is used in a generated third-party config
 	// If Step is nil, then all steps are ran
-	Step *int
+	Step *int64
 
 	// BuildID is a unique identifier typically assigned by a CI system.
 	// In Docker / CLI mode, this will likely be populated by a random UUID if not provided.

--- a/plumbing/cmd/commands/run.go
+++ b/plumbing/cmd/commands/run.go
@@ -81,7 +81,7 @@ func Run(ctx context.Context, opts *RunOpts) *exec.Cmd {
 	logger.Infoln("Running shipwright pipeline with args", cmdArgs)
 
 	if args.Step != nil {
-		cmdArgs = append(cmdArgs, "-step", strconv.Itoa(*args.Step))
+		cmdArgs = append(cmdArgs, "-step", strconv.FormatInt(*args.Step, 10))
 	}
 
 	cmd := exec.CommandContext(ctx, "go", cmdArgs...)

--- a/plumbing/cmdutil/command.go
+++ b/plumbing/cmdutil/command.go
@@ -8,10 +8,14 @@ import (
 
 // CommandOpts is a list of arguments that can be provided to the StepCommand function.
 type CommandOpts struct {
-	// Path is an optional argument that refers to the path of the pipeline. For example, if our plan is to have this function generate `shipwright ./ci`, the 'Path' would be './ci'.
-	Path string
 	// Step is the pipeline step this command is being generated for. The step contains a lot of necessary information for generating a command, mostly around arguments.
 	Step pipeline.Step[pipeline.Action]
+
+	// CompiledPipeline is an optional argument. If it is supplied, this value will be used as the first argument in the command instead of the shipwright command.
+	// This option is useful scenarios where the 'shipwright' command will not be available, but the pipeline has been compiled.
+	CompiledPipeline string
+	// Path is an optional argument that refers to the path of the pipeline. For example, if our plan is to have this function generate `shipwright ./ci`, the 'Path' would be './ci'.
+	Path string
 	// BuildID is an optional argument that will be supplied to the 'shipwright' command as '-build-id'.
 	BuildID string
 }
@@ -38,7 +42,13 @@ func StepCommand(c pipeline.Configurer, opts CommandOpts) ([]string, error) {
 		args = append(args, fmt.Sprintf("-build-id=%s", opts.BuildID))
 	}
 
-	cmd := append([]string{"shipwright", fmt.Sprintf("-step=%d", opts.Step.Serial)}, args...)
+	name := "shipwright"
+
+	if p := opts.CompiledPipeline; p != "" {
+		name = p
+	}
+
+	cmd := append([]string{name, fmt.Sprintf("-step=%d", opts.Step.Serial)}, args...)
 	if opts.Path != "" {
 		cmd = append(cmd, opts.Path)
 	}

--- a/plumbing/flag_optional_int.go
+++ b/plumbing/flag_optional_int.go
@@ -3,13 +3,13 @@ package plumbing
 import "strconv"
 
 type OptionalInt struct {
-	Value int
+	Value int64
 	Valid bool
 }
 
 func (o *OptionalInt) String() string {
 	if o.Valid {
-		return strconv.Itoa(o.Value)
+		return strconv.FormatInt(o.Value, 10)
 	}
 
 	return ""
@@ -20,7 +20,7 @@ func (o *OptionalInt) Set(v string) error {
 		return nil
 	}
 
-	i, err := strconv.Atoi(v)
+	i, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
 		return err
 	}

--- a/plumbing/images.go
+++ b/plumbing/images.go
@@ -2,7 +2,7 @@ package plumbing
 
 import "fmt"
 
-const DefaultRepo = "ghcr.io/grafana/shipwright"
+const DefaultRepo = "grafana/shipwright"
 
 func DefaultImage(version string) string {
 	// TODO don't hardcode this image but for now I don't care good luck
@@ -10,5 +10,5 @@ func DefaultImage(version string) string {
 }
 
 func SubImage(image, version string) string {
-	return fmt.Sprintf("%s/%s:%s", DefaultRepo, image, version)
+	return fmt.Sprintf("%s:%s-%s", DefaultRepo, version, image)
 }

--- a/plumbing/pipeline/clients/drone/schema.go
+++ b/plumbing/pipeline/clients/drone/schema.go
@@ -54,9 +54,10 @@ func NewStep(c pipeline.Configurer, path string, step pipeline.Step[pipeline.Act
 	}
 
 	cmd, err := cmdutil.StepCommand(c, cmdutil.CommandOpts{
-		Path:    path,
-		Step:    step,
-		BuildID: "$DRONE_BUILD_NUMBER",
+		CompiledPipeline: PipelinePath,
+		Path:             path,
+		Step:             step,
+		BuildID:          "$DRONE_BUILD_NUMBER",
 	})
 
 	if err != nil {

--- a/plumbing/pipeline/dag/dag.go
+++ b/plumbing/pipeline/dag/dag.go
@@ -201,6 +201,8 @@ func (g *Graph[T]) BreadthFirstSearch(id int64, visitFunc VisitFunc[T]) error {
 		return ErrorNoVisitFunc
 	}
 
+	g.resetVisited()
+
 	queue := []int64{id}
 	if err := g.visit(id, visitFunc); err != nil {
 		if errors.Is(err, ErrorBreak) {

--- a/shipwright.go
+++ b/shipwright.go
@@ -259,12 +259,12 @@ func (s *Shipwright[T]) Execute(ctx context.Context) error {
 	)
 	// If the user has specified a specific step, then cut the "Collection" to only include that step
 	if s.Opts.Args.Step != nil {
-		step, err := collection.BySerial(*s.Opts.Args.Step)
+		step, err := collection.BySerial(ctx, *s.Opts.Args.Step)
 		if err != nil {
 			return fmt.Errorf("could not find step. Error: %w", err)
 		}
 
-		collection = collection.Sub(step)
+		collection = collection.Sub(step...)
 	}
 
 	if err := s.Client.Done(ctx, collection); err != nil {


### PR DESCRIPTION
* Drone pipelines now compile the pipeline as the first step.
* Drone pipelines now include a volume for storing the compiled
  pipeline.
* Drone steps now refer to the compiled pipeline instead of the
  'shipwright' command. If users supply their own docker images for a
  step, this should prevent issues from arising if 'Shipwright' isn't
  installed.
* Drone steps include a volume mount for using the compiled pipeline.
* The -step argument / implementation has been updated to use the DAG.