### PR TITLE
Pass and use arguments for golang build.

### DIFF
--- a/golang/build.go
+++ b/golang/build.go
@@ -7,13 +7,29 @@ import (
 	"github.com/grafana/scribe/plumbing/pipeline"
 )
 
-func BuildStep(pkg, output string) pipeline.Step {
+func BuildStep(pkg, output string, args, env []string) pipeline.Step {
 	return pipeline.NewStep(func(ctx context.Context, opts pipeline.ActionOpts) error {
 		return x.RunBuild(ctx, x.BuildOpts{
 			Pkg:    pkg,
 			Output: output,
 			Stdout: opts.Stdout,
 			Stderr: opts.Stderr,
+			Env:    env,
+			Args:   args,
 		})
 	})
+}
+
+func BuildAction(pkg, output string, args, env []string) pipeline.Action {
+	return func(ctx context.Context, opts pipeline.ActionOpts) error {
+		opts.Logger.Infoln("args: ", args)
+		return x.RunBuild(ctx, x.BuildOpts{
+			Pkg:    pkg,
+			Output: output,
+			Stdout: opts.Stdout,
+			Stderr: opts.Stderr,
+			Env:    env,
+			Args:   args,
+		})
+	}
 }

--- a/golang/x/build.go
+++ b/golang/x/build.go
@@ -10,6 +10,7 @@ import (
 
 type BuildOpts struct {
 	Env    []string
+	Args   []string
 	Pkg    string
 	Output string
 	Module string
@@ -19,12 +20,16 @@ type BuildOpts struct {
 }
 
 func Build(ctx context.Context, opts BuildOpts) *exec.Cmd {
+	// for the go build command optional arguments have to come before the -o output and package name we are building
+	fullArgs := append([]string{"build"}, opts.Args...)
+	fullArgs = append(fullArgs, []string{"-o", opts.Output, opts.Pkg}...)
+
 	return swexec.CommandWithOpts(ctx, swexec.RunOpts{
 		Stdout: opts.Stdout,
 		Stderr: opts.Stderr,
 		Path:   opts.Module,
 		Name:   "go",
-		Args:   []string{"build", "-o", opts.Output, opts.Pkg},
+		Args:   fullArgs,
 		Env:    opts.Env,
 	})
 }


### PR DESCRIPTION
Passes args to the golang build functions and also properly adds them in between `go build` and the `-o <filename>` flags.

Signed-off-by: Callum Styan <callumstyan@gmail.com>